### PR TITLE
Add link to Digital Earth Australia Jupyter notebooks repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Please do explore these accounts, there are some absolutely brilliant projects o
 - [Oliverhagolle github](https://github.com/olivierhagolle)
   - [Sentinel-download](https://github.com/olivierhagolle/Sentinel-download) - Automated download of Sentinel-2 L1C data from ESA (through wget)
   - [LANDSAT-Download](https://github.com/olivierhagolle/LANDSAT-Download) - Automated download of LANDSAT data from USGS website
+- [Digital Earth Australia Notebooks](https://github.com/GeoscienceAustralia/dea-notebooks/) - Jupyter Notebooks, tools and workflows for continental-scale earth observation/geospatial analysis with [Open Data Cube](https://www.opendatacube.org/) and `xarray`
 
 ## GDAL of course
 


### PR DESCRIPTION
Added a link to the DEA Notebooks repository, which contains a wide selection of Jupyter notebooks and geospatial tools and workflows for continental-scale earth observation analysis with Open Data Cube and xarray (including a beginner's guide for getting started with Open Data Cube).