### PR TITLE
TernausNetV2 link fix + possible addition suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ R is not my area of expertise so this section is lighter than I'd like, plus I'd
 - [Robin Cole on satellite imagery and deep learning resources](https://github.com/robmarkcole/satellite-image-deep-learning) - Resources for deep learning with satellite & aerial imagery
 
 #### Specific examples
-- [TernausNetV2](https://github.com/ternaus/TernausNetV2) - TernausNetV2: Fully Convolutional Network for Instance Segmentation [paper](https://arxiv.org/abs/1806.00844) 
+- [TernausNetV2](https://github.com/ternaus/TernausNetV2) - TernausNetV2: Fully Convolutional Network for Instance Segmentation ([paper](https://arxiv.org/abs/1806.00844))
 - [CNN-Sentinel](https://github.com/jensleitloff/CNN-Sentinel) -Analyzing Sentinel-2 satellite data in Python with Keras (repository of our talks at Minds Mastering Machines 2019 and PyCon 2018)
 - [Image patches](https://github.com/Vooban/Smoothly-Blend-Image-Patches) - Using a U-Net for image segmentation, blending predicted patches smoothly is a must to please the human eye.
 - [Fast AI Satellite imagery resources](https://forums.fast.ai/t/geospatial-deep-learning-resources-study-group/31044)

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ R is not my area of expertise so this section is lighter than I'd like, plus I'd
 - [Robin Cole on satellite imagery and deep learning resources](https://github.com/robmarkcole/satellite-image-deep-learning) - Resources for deep learning with satellite & aerial imagery
 
 #### Specific examples
-- [TernausNetV2](https://github.com/ternaus/TernausNetV2) - TernausNetV2: Fully Convolutional Network for Instance Segmentation [paper](TernausNetV2: Fully Convolutional Network for Instance Segmentation) 
+- [TernausNetV2](https://github.com/ternaus/TernausNetV2) - TernausNetV2: Fully Convolutional Network for Instance Segmentation [paper](https://arxiv.org/abs/1806.00844) 
 - [CNN-Sentinel](https://github.com/jensleitloff/CNN-Sentinel) -Analyzing Sentinel-2 satellite data in Python with Keras (repository of our talks at Minds Mastering Machines 2019 and PyCon 2018)
 - [Image patches](https://github.com/Vooban/Smoothly-Blend-Image-Patches) - Using a U-Net for image segmentation, blending predicted patches smoothly is a must to please the human eye.
 - [Fast AI Satellite imagery resources](https://forums.fast.ai/t/geospatial-deep-learning-resources-study-group/31044)


### PR DESCRIPTION
Fixing the link for TernausNetV2 paper

![image](https://user-images.githubusercontent.com/18722560/89728971-a5e93c00-da31-11ea-9be9-038fa96fd0bb.png)

Btw, I also stumbled upon these [awesome earth observation textbooks](https://www.eoa.org.au/earth-observation-textbooks). There is no code, so I am not sure they would belong to this list, but they might still make a good addition (they definitely help me loads). Especially [Volume 2](https://www.eoa.org.au/earth-observation-textbooks#volume2) is super-relevant.