### PR TITLE
Adding EOReader library

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ This section full of great code and projects related to processing optical satel
 - [ukis-csmask](https://github.com/dlr-eoc/ukis-csmask) - masks clouds and cloud shadows in Sentinel-2, Landsat-8, Landsat-7 and Landsat-5 images `Python`
 - [jeolib-pyjeo](https://github.com/ec-jrc/jeolib-pyjeo) - pyjeo is a library for image processing for geospatial data implemented in JRC Ispra. `Python`
 - [pyrgis](https://github.com/PratyushTripathy/pyrsgis) - This repository cointains the source code of the 'pyrsgis' `Python` package. 
+- [EOReader](https://github.com/sertit/eoreader) - Opensource `Python` library reading optical and SAR sensors, loading and stacking bands in a sensor-agnostic way.
 
 ### Cloud Native Geospatial
 - [aws-sat-api-py](https://github.com/RemotePixel/remotepixel-api) - Process Satellite data using AWS Lambda functions


### PR DESCRIPTION
Adding [EOReader](https://github.com/sertit/eoreader) library.
The documentation can be found [here](https://eoreader.readthedocs.io/en/latest).

## Introduction
**EOReader** is a remote-sensing opensource python library reading optical and SAR sensors, loading and stacking bands, clouds, DEM and index in a sensor-agnostic way. 

## Optical

It aims to allow the user to load in a pythonic-way optical bands, index and clouds.
You can see how EOReader works in real by looking at [this tutorial](https://eoreader.readthedocs.io/en/latest/notebooks/base.html).

|Sensors | Product Types | Use archive |
|--- | --- | --- |
|Sentinel-2 | L1C & L2A | ✅ |
|Sentinel-2 Theia | L2A | ✅ |
|Sentinel-3 SLSTR | RBT | ✅ |
|Sentinel-3 OLCI | EFR | ✅ |
|Landsat 8 OLCI | Level 1 | Collection 1: ❌, Collection 2: ✅ |
|Landsat 7 ETM | Level 1 | Collection 1: ❌, Collection 2: ✅ |
|Landsat 5 TM | Level 1 | Collection 1: ❌, Collection 2: ✅ |
|Landsat 4 TM  | Level 1 | Collection 1: ❌, Collection 2: ✅ |
|Landsat 5 MSS | Level 1 | Collection 1: ❌, Collection 2: ✅ |
|Landsat 4 MSS | Level 1 | Collection 1: ❌, Collection 2: ✅ |
|Landsat 3 MSS | Level 1 | Collection 1: ❌, Collection 2: ✅ |
|Landsat 2 MSS | Level 1 | Collection 1: ❌, Collection 2: ✅ |
|Landsat 1 MSS | Level 1 | Collection 1: ❌, Collection 2: ✅ |
|PlanetScope | L3A & L3B | ✅ |
|Pleiades | SEN, PRJ, ORT & MOS | ✅ |
|SPOT 7 | SEN, PRJ, ORT & MOS | ✅ |
|SPOT 6 | SEN, PRJ, ORT & MOS | ✅ |
|GeoEye-1*  | Standard & Ortho | ✅ |
|WorldView-2*  | Standard & Ortho | ✅ |
|WorldView-3* | Standard & Ortho | ✅ |
|WorldView-4* | Standard & Ortho | ✅ |

\* *Archived Landsat Collection-1 are not managed because of the tar.gz format, which is too slow to process. It is better to work on the extracted product.*

\* *Other Maxar satellites (such as WorldView-1, QuickBird...) with the same file format should be supported.*

## SAR
It aims to allow the user to load in a pythonic-way orthorectified SAR GRD data, by binding ESA SNAP `gpt`.
You can see how EOReader works in real by looking at [this tutorial](https://eoreader.readthedocs.io/en/latest/notebooks/SAR.html).

| Sensor | Product Type | Handled |
| --- | --- | --- |
| `COSMO-Skymed` 1st and 2nd Generation | SCS | ✅ |
| `COSMO-SkyMed` 1st Generation | DGM | ✅ |
| `COSMO-SkyMed` 2nd Generation | DGM | ⚠️ |
| `COSMO-SkyMed` 1st and 2nd Generation | GEC, GTC | ⚠️ | 
| `ICEYE` | SLC | ❌* |
| `ICEYE` |GRD | ✅ | 
| `ICEYE` | ORTHO | 💤 |
| `RADARSAT Constellation Mission` | SLC | ⚠️ | 
| `RADARSAT Constellation Mission` | GRC, GCC, GCD | ⚠️ |
| `RADARSAT Constellation Mission` | GRD | ✅ | 
| `RADARSAT-2` | SLC | ✅| 
| `RADARSAT-2` | SGX, SCN, SCW,<br>SCF, SCS, SSG, SPG | ⚠️ |
| `RADARSAT-2` | SGF | ✅ |
| `TerraSAR-X`, `TanDEM-X`, `PAZ SAR` | SSC | ✅ | 
| `TerraSAR-X`, `TanDEM-X`, `PAZ SAR` | MGD | ✅ |
| `TerraSAR-X`, `TanDEM-X`, `PAZ SAR` | GEC | ⚠️ |
| `TerraSAR-X`, `TanDEM-X`, `PAZ SAR` | EEC | ✅ |
| `Sentinel-1` | SLC | ✅ | 
| `Sentinel-1` | GRD | ✅ |

\**always given with a GRD image*

✅: Tested   
⚠️: Never tested, **use it at your own risk!**  
❌: Not handled   
💤: Waiting for the release  

Those sensors are planned in a near future:
- `SAOCOM-1`

## Context

This library has been created in the context of the Copernicus Emergency Management Service rapid mapping and risk and recovery.

In these activations, it is needed to deliver information (such as flood or fire delineations, landslides mapping, etc.) based on various sensors (optical and SAR). As every minute counts in production, it seemed crucial to harmonize the ground on which are built our production tools, in order to make them as sensor-agnostic as possible.